### PR TITLE
fix: remove prompts from terraform automation

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -33,10 +33,11 @@ jobs:
         id: plan
         run: |
           cd infra
-          terraform plan
+          terraform plan -input=false -out=tfplan
+          terraform show tfplan
 
       - name: Apply Terraform
         if: steps.plan.outcome == 'success' && github.event_name == 'push'
         run: |
           cd infra
-          terraform apply
+          terraform apply -input=false tfplan


### PR DESCRIPTION
Remove Terraform prompts in GHA

## Description

Terraform prompts when applying changes, ignore this and pass in plan output

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In GHA

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
