### PR TITLE
fix: Reroll ECS constainers on update

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -77,6 +77,7 @@ resource "aws_ecs_service" "footystats_web_service" {
   desired_count                      = 1   # Setting the number of containers we want deployed
   deployment_minimum_healthy_percent = 0   # Allow for no instance on deployment for roll over, may cause outage (503).
   deployment_maximum_percent         = 200 # Allow for two instances on deployment, to roll over, may cause multiple different versions.
+  force_new_deployment = true
 
   load_balancer {
     target_group_arn = aws_lb_target_group.footystats_web_target_group.arn # Referencing our target group


### PR DESCRIPTION
Fixes #7

# Reroll ECS service on deploy

## Description

Force containers to reroll on deployment, so they don't contain old image code

Fixes #7 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
